### PR TITLE
ANDROID-2176 Update repository declaration to explicitly work for Zello dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ lifecycleLivedataKtx = "2.7.0"
 lifecycleViewmodelKtx = "2.7.0"
 navigationFragmentKtx = "2.7.7"
 navigationUiKtx = "2.7.7"
-sdk = "1.0.0"
+sdk = "1.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,7 @@ dependencyResolutionManagement {
 		maven {
 			url = uri("https://zello-sdk.s3.amazonaws.com/android/latest")
 			content {
-				includeGroupAndSubgroups("com.zello")
+				includeGroup("com.zello")
 			}
 		}
 	}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,11 +14,14 @@ pluginManagement {
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	repositories {
-		google()
-		mavenCentral()
 		maven {
 			url = uri("https://zello-sdk.s3.amazonaws.com/android/latest")
+			content {
+				includeGroupAndSubgroups("com.zello")
+			}
 		}
+		google()
+		mavenCentral()
 	}
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,14 +14,14 @@ pluginManagement {
 dependencyResolutionManagement {
 	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
 	repositories {
+		google()
+		mavenCentral()
 		maven {
 			url = uri("https://zello-sdk.s3.amazonaws.com/android/latest")
 			content {
 				includeGroupAndSubgroups("com.zello")
 			}
 		}
-		google()
-		mavenCentral()
 	}
 }
 


### PR DESCRIPTION
1. Updates the Zello SDK version in the example to the latest
2. Updates the Zello SDK repository declaration to reflect best practices. By specifying a group ID for the Zello SDK repository, we ensure the repository will never be queried for any other dependencies that the project might include.